### PR TITLE
update ffmpeg-hardware-acceleration.ts

### DIFF
--- a/common/src/ffmpeg-hardware-acceleration.ts
+++ b/common/src/ffmpeg-hardware-acceleration.ts
@@ -63,10 +63,10 @@ export function getH264DecoderArgs(): CodecArgs {
 
     const ret: CodecArgs = {
         'Nvidia CUDA': [
-            '-vsync', '0', '–hwaccel', 'cuda', '-hwaccel_output_format', 'cuda',
+            '-vsync', '0', '-hwaccel', 'cuda', '-hwaccel_output_format', 'yuv420p',
         ],
         'Nvidia CUVID': [
-            '-vsync', '0', '–hwaccel', 'cuvid', '-c:v', 'h264_cuvid',
+            '-vsync', '0', '-hwaccel', 'cuvid', '-c:v', 'h264_cuvid', '-hwaccel_output_format', 'yuv420p',
         ],
     };
 
@@ -112,7 +112,7 @@ export function getH264EncoderArgs() {
         // h264_v4l2m2m h264_vaapi nvenc_h264
         encoders['V4L2'] = 'h264_v4l2m2m';
         encoders['VAAPI'] = 'h264_vaapi';
-        encoders['Nvidia'] = 'nvenc_h264';
+        encoders['Nvidia'] = 'h264_nvenc';
     }
 
     const encoderArgs: CodecArgs = {};


### PR DESCRIPTION
- fix nvidia pipeline arguments:
   - replace bad "-" characters with proper dashes (in -hwaccel)
   - add  hwaccel_output_format parameter to the cuvid pipeline as well
       - change hwaccel output format to something forcing the pipeline to download the frames from video memory (not doing so breaks the pipeline completely in case custom user filter arguments contain software scale= (for cuda/cuvid scale_cuda=/scale_npp= would be needed) or/and transcoding is involved which for the moment uses scale=
 
- update depretiated encoder nvenc_h264 -> h264_nvenc